### PR TITLE
UI redesign

### DIFF
--- a/pan3d/viewer/engine.py
+++ b/pan3d/viewer/engine.py
@@ -56,8 +56,8 @@ class MeshBuilder:
         ]
         self._state.coordinates = []
         self._state.dataset_ready = True
-        # Set first array as active
-        # TODO self._state.array_active = list(dataset.data_vars.keys())[0]
+        if len(self._state.data_vars) > 0:
+            self._state.array_active = self._state.data_vars[0]["name"]
 
     def clear_dataset(self, **kwargs):
         self._state.dataset_path = None
@@ -65,6 +65,7 @@ class MeshBuilder:
         self._state.coordinates = []
         self._state.dataset_ready = False
         self._state.array_active = None
+        self._state.active_tree_nodes = []
         self._state.grid_x_array = None
         self._state.grid_y_array = None
         self._state.grid_z_array = None
@@ -81,9 +82,11 @@ class MeshBuilder:
 
     def on_active_array(self, array_active, **kwargs):
         if array_active is None or not self._state.dataset_ready:
+            self._state.active_tree_nodes = []
             return
         self._algorithm.data_array = self._dataset[array_active]
         self._state.coordinates = list(self.data_array.coords.keys())
+        self._state.active_tree_nodes = [array_active]
 
     def bind_x(self, grid_x_array, **kwargs):
         self.algorithm.x = grid_x_array

--- a/pan3d/viewer/engine.py
+++ b/pan3d/viewer/engine.py
@@ -169,8 +169,8 @@ class MeshViewer:
         if not self._state.array_active:
             return
         try:
-            self.mesher.algorithm.Update()
             self.mesher.validate_mesh()
+            self.mesher.algorithm.Update()
             self.actor = self.plotter.add_mesh(
                 self.mesher.algorithm,
                 show_edges=self._state.view_edge_visiblity,

--- a/pan3d/viewer/engine.py
+++ b/pan3d/viewer/engine.py
@@ -74,7 +74,10 @@ class MeshBuilder:
         self._state.error_message = None
 
     def validate_mesh(self):
-        self._algorithm.data_array.pyvista.mesh(
+        data_array = self._algorithm.data_array
+        if self._algorithm.time:
+            data_array = data_array[{self._algorithm.time: self._state.time_max}]
+        data_array.pyvista.mesh(
             self._algorithm.x,
             self._algorithm.y,
             self._algorithm.z,
@@ -166,8 +169,8 @@ class MeshViewer:
         if not self._state.array_active:
             return
         try:
-            self.mesher.validate_mesh()
             self.mesher.algorithm.Update()
+            self.mesher.validate_mesh()
             self.actor = self.plotter.add_mesh(
                 self.mesher.algorithm,
                 show_edges=self._state.view_edge_visiblity,

--- a/pan3d/viewer/engine.py
+++ b/pan3d/viewer/engine.py
@@ -73,6 +73,15 @@ class MeshBuilder:
         self._state.time_max = 0
         self._state.error_message = None
 
+    def validate_mesh(self):
+        self._algorithm.data_array.pyvista.mesh(
+            self._algorithm.x,
+            self._algorithm.y,
+            self._algorithm.z,
+            self._algorithm.order,
+            self._algorithm.component,
+        )
+
     @property
     def algorithm(self):
         return self._algorithm
@@ -88,6 +97,10 @@ class MeshBuilder:
         self._algorithm.data_array = self._dataset[array_active]
         self._state.coordinates = list(self.data_array.coords.keys())
         self._state.active_tree_nodes = [array_active]
+        self._state.grid_x_array = None
+        self._state.grid_y_array = None
+        self._state.grid_z_array = None
+        self._state.grid_t_array = None
         self._ctrl.reset()
 
     def bind_x(self, grid_x_array, **kwargs):
@@ -153,17 +166,8 @@ class MeshViewer:
         if not self._state.array_active:
             return
         try:
-            try:
-                # check for valid data
-                self.mesher.algorithm.RequestData(None, None, None)
-            except AttributeError:
-                # TODO: AttributeError will be raised when RequestData
-                # is otherwise successful because we pass None to outputData
-                # We can ignore this and continue, but it would be better to pass
-                # the proper type to outputData
-                pass
-            self.mesher.algorithm.Modified()
-            self.plotter.clear()
+            self.mesher.validate_mesh()
+            self.mesher.algorithm.Update()
             self.actor = self.plotter.add_mesh(
                 self.mesher.algorithm,
                 show_edges=self._state.view_edge_visiblity,

--- a/pan3d/viewer/engine.py
+++ b/pan3d/viewer/engine.py
@@ -136,7 +136,7 @@ class MeshViewer:
         self.actor = None
 
         # controller
-        ctrl.get_render_window = lambda: self.plotter.ren_win
+        ctrl.get_plotter = lambda: self.plotter
         ctrl.reset = self.reset
 
         self._state.x_scale = 1

--- a/pan3d/viewer/ui.py
+++ b/pan3d/viewer/ui.py
@@ -179,7 +179,7 @@ def initialize(server):
                                 v_show="grid_t_array && time_max > 0",
                                 v_model=("time_index", 0),
                                 classes="ml-2",
-                                label="Scale",
+                                label="Index",
                                 min=0,
                                 max=("time_max", 0),
                                 step=1,

--- a/pan3d/viewer/ui.py
+++ b/pan3d/viewer/ui.py
@@ -1,5 +1,6 @@
 from trame.ui.vuetify import SinglePageWithDrawerLayout
-from trame.widgets import html, vtk, vuetify
+from trame.widgets import html, vuetify
+from pyvista.trame.ui import plotter_ui
 
 
 # Create single page layout type
@@ -189,14 +190,14 @@ def initialize(server):
 
                 with html.Div(
                     v_show="array_active",
-                    style="height: 100%",
+                    style="height: 100%; position: relative;",
                 ):
-                    with vtk.VtkRemoteView(
-                        ctrl.get_render_window(),
+                    with plotter_ui(
+                        ctrl.get_plotter(),
                         interactive_ratio=1,
-                    ) as vtk_view:
-                        ctrl.view_update = vtk_view.update
-                        ctrl.reset_camera = vtk_view.reset_camera
+                    ) as plot_view:
+                        ctrl.view_update = plot_view.update
+                        ctrl.reset_camera = plot_view.reset_camera
 
         # Footer
         # layout.footer.hide()

--- a/pan3d/viewer/ui.py
+++ b/pan3d/viewer/ui.py
@@ -17,50 +17,63 @@ def initialize(server):
             vuetify.VSpacer()
 
             vuetify.VCheckbox(
-                v_show="array_active",
                 v_model=("view_edge_visiblity", True),
                 dense=True,
                 hide_details=True,
                 on_icon="mdi-border-all",
                 off_icon="mdi-border-outside",
-                classes="ma-2",
             )
 
             with vuetify.VBtn(
-                v_show="array_active",
                 icon=True,
                 click=ctrl.reset,
             ):
                 vuetify.VIcon("mdi-crop-free")
 
-            vuetify.VSelect(
+            vuetify.VSlider(
                 label="Resolution",
-                v_show="array_active",
                 v_model=("resolution", 1.0),
-                items=("resolutions", [0.05, 0.25, 0.5, 1.0]),
+                min=0.5,
+                max=1,
+                step=0.25,
                 hide_details=True,
                 dense=True,
-                outlined=True,
-                classes="pt-1 ml-2",
-                style="max-width: 150px",
+                style="max-width: 300px",
             )
-
-            with vuetify.VBtn(
-                v_show="dataset_ready",
-                icon=True,
-                click=ctrl.clear_dataset,
-            ):
-                vuetify.VIcon("mdi-delete")
 
         # Drawer
         with layout.drawer:
+            with vuetify.VForm(classes="pa-1"):
+                datasets = [
+                    "air_temperature",
+                    "basin_mask",
+                    "eraint_uvz",
+                ]
+                vuetify.VSelect(
+                    label="Choose a dataset",
+                    v_model="dataset_path",
+                    items=("datasets", datasets),
+                    hide_details=True,
+                    dense=True,
+                    clearable=True,
+                    outlined=True,
+                    classes="pt-1",
+                    click_clear=ctrl.clear_dataset,
+                )
+
+            vuetify.VCardText(
+                "Available Arrays",
+                v_show="dataset_ready",
+            )
+
             with vuetify.VTreeview(
                 v_show="dataset_ready",
                 dense=True,
                 activatable=True,
+                active=("active_tree_nodes",),
                 items=("data_vars",),
-                update_active="array_active = data_vars[$event[0] || 0]?.name",
-                # TODO: set active/selected on startup
+                item_key="name",
+                update_active="array_active = $event[0]",
                 multiple_active=False,
             ):
                 with vuetify.Template(v_slot_label="{ item }"):
@@ -68,152 +81,122 @@ def initialize(server):
 
         # Content
         with layout.content:
-            with vuetify.VContainer(fluid=True, classes="pa-0 fill-height"):
-                with vuetify.VCol(
-                    v_show="!dataset_ready",
-                    classes="fill-height",
-                ):
-                    with vuetify.VForm():
-                        datasets = [
-                            "air_temperature",
-                            "basin_mask",
-                            "eraint_uvz",
-                        ]
-                        vuetify.VSelect(
-                            label="Choose a dataset",
-                            v_model="dataset_path",
-                            items=("datasets", datasets),
-                            hide_details=True,
-                            dense=True,
-                            outlined=True,
-                            classes="pt-1",
-                        )
-                with vuetify.VCol(
+            with html.Div(
+                classes="d-flex",
+                style="flex-direction: column; height: 100%",
+            ):
+                with vuetify.VContainer(
                     v_show="array_active",
-                    classes="fill-height",
+                    classes="pa-2",
+                    fluid=True,
                 ):
-                    with vuetify.VCard(style="flex: none;"):
-                        vuetify.VDivider()
-                        with vuetify.VCardText():
-                            with vuetify.VCol():
-                                with vuetify.VRow():
-                                    html.Div("X:", classes="text-subtitle-2 pr-2")
-                                    html.Div("{{ grid_x_array || 'Undefined' }}")
-                                    vuetify.VSpacer()
-                                    vuetify.VSlider(
-                                        label="X Scale",
-                                        v_show="grid_x_array",
-                                        v_model=("x_scale", 0),
-                                        min=1,
-                                        max=1000,
-                                        step=10,
-                                        dense=True,
-                                        hide_details=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    vuetify.VSelect(
-                                        v_model=("grid_x_array", None),
-                                        items=("coordinates",),
-                                        hide_details=True,
-                                        dense=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    with vuetify.VBtn(
-                                        icon=True,
-                                        click="grid_x_array = undefined",
-                                    ):
-                                        vuetify.VIcon("mdi-delete")
-                                with vuetify.VRow():
-                                    html.Div("Y:", classes="text-subtitle-2 pr-2")
-                                    html.Div("{{ grid_y_array || 'Undefined' }}")
-                                    vuetify.VSpacer()
-                                    vuetify.VSlider(
-                                        label="Y Scale",
-                                        v_show="grid_y_array",
-                                        v_model=("y_scale", 0),
-                                        min=1,
-                                        max=1000,
-                                        step=10,
-                                        dense=True,
-                                        hide_details=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    vuetify.VSelect(
-                                        v_model=("grid_y_array", None),
-                                        items=("coordinates",),
-                                        hide_details=True,
-                                        dense=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    with vuetify.VBtn(
-                                        icon=True,
-                                        click="grid_y_array = undefined",
-                                    ):
-                                        vuetify.VIcon("mdi-delete")
-                                with vuetify.VRow():
-                                    html.Div("Z:", classes="text-subtitle-2 pr-2")
-                                    html.Div("{{ grid_z_array || 'Undefined' }}")
-                                    vuetify.VSpacer()
-                                    vuetify.VSlider(
-                                        label="Z Scale",
-                                        v_show="grid_z_array",
-                                        v_model=("z_scale", 0),
-                                        min=1,
-                                        max=1000,
-                                        step=10,
-                                        dense=True,
-                                        hide_details=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    vuetify.VSelect(
-                                        v_model=("grid_z_array", None),
-                                        items=("coordinates",),
-                                        hide_details=True,
-                                        dense=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    with vuetify.VBtn(
-                                        icon=True,
-                                        click="grid_z_array = undefined",
-                                    ):
-                                        vuetify.VIcon("mdi-delete")
-                                with vuetify.VRow():
-                                    html.Div("T:", classes="text-subtitle-2 pr-2")
-                                    html.Div("{{ grid_t_array || 'Undefined' }}")
-                                    vuetify.VSpacer()
-                                    vuetify.VSlider(
-                                        label="Time",
-                                        v_show="grid_t_array && time_max > 0",
-                                        v_model=("time_index", 0),
-                                        min=0,
-                                        max=("time_max", 0),
-                                        step=1,
-                                        dense=True,
-                                        hide_details=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    vuetify.VSelect(
-                                        v_model=("grid_t_array", None),
-                                        items=("coordinates",),
-                                        hide_details=True,
-                                        dense=True,
-                                        style="max-width: 250px;",
-                                    )
-                                    with vuetify.VBtn(
-                                        icon=True,
-                                        click="grid_t_array = undefined",
-                                    ):
-                                        vuetify.VIcon("mdi-delete")
-                    with html.Div(
-                        style="display: flex; flex: 1; height: calc(100vh - 300px);"
-                    ):
-                        with vtk.VtkRemoteView(
-                            ctrl.get_render_window(),
-                            # v_show="view_mode === 'view_grid'",
-                            interactive_ratio=1,
-                        ) as vtk_view:
-                            ctrl.view_update = vtk_view.update
-                            ctrl.reset_camera = vtk_view.reset_camera
+                    with vuetify.VCol():
+                        with vuetify.VRow():
+                            html.Div("X:", classes="text-subtitle-2 pr-2")
+                            vuetify.VSelect(
+                                v_model=("grid_x_array", None),
+                                items=("coordinates",),
+                                hide_details=True,
+                                dense=True,
+                                clearable="True",
+                                clear="grid_x_array = undefined",
+                                style="max-width: 250px;",
+                            )
+                            vuetify.VSlider(
+                                v_show="grid_x_array",
+                                v_model=("x_scale", 0),
+                                classes="ml-2",
+                                label="Scale",
+                                min=1,
+                                max=1000,
+                                step=10,
+                                dense=True,
+                                hide_details=True,
+                                style="max-width: 250px;",
+                            )
+
+                        with vuetify.VRow():
+                            html.Div("Y:", classes="text-subtitle-2 pr-2")
+                            vuetify.VSelect(
+                                v_model=("grid_y_array", None),
+                                items=("coordinates",),
+                                hide_details=True,
+                                dense=True,
+                                clearable="True",
+                                clear="grid_y_array = undefined",
+                                style="max-width: 250px;",
+                            )
+                            vuetify.VSlider(
+                                v_show="grid_y_array",
+                                v_model=("y_scale", 0),
+                                classes="ml-2",
+                                label="Scale",
+                                min=1,
+                                max=1000,
+                                step=10,
+                                dense=True,
+                                hide_details=True,
+                                style="max-width: 250px;",
+                            )
+
+                        with vuetify.VRow():
+                            html.Div("Z:", classes="text-subtitle-2 pr-2")
+                            vuetify.VSelect(
+                                v_model=("grid_z_array", None),
+                                items=("coordinates",),
+                                hide_details=True,
+                                dense=True,
+                                clearable="True",
+                                clear="grid_z_array = undefined",
+                                style="max-width: 250px;",
+                            )
+                            vuetify.VSlider(
+                                v_show="grid_z_array",
+                                v_model=("z_scale", 0),
+                                classes="ml-2",
+                                label="Scale",
+                                min=1,
+                                max=1000,
+                                step=10,
+                                dense=True,
+                                hide_details=True,
+                                style="max-width: 250px;",
+                            )
+
+                        with vuetify.VRow():
+                            html.Div("T:", classes="text-subtitle-2 pr-2")
+                            vuetify.VSelect(
+                                v_model=("grid_t_array", None),
+                                items=("coordinates",),
+                                hide_details=True,
+                                dense=True,
+                                clearable="True",
+                                clear="grid_t_array = undefined",
+                                style="max-width: 250px;",
+                            )
+                            vuetify.VSlider(
+                                v_show="grid_t_array && time_max > 0",
+                                v_model=("time_index", 0),
+                                classes="ml-2",
+                                label="Scale",
+                                min=0,
+                                max=("time_max", 0),
+                                step=1,
+                                dense=True,
+                                hide_details=True,
+                                style="max-width: 250px;",
+                            )
+
+                with html.Div(
+                    v_show="array_active",
+                    style="height: 100%",
+                ):
+                    with vtk.VtkRemoteView(
+                        ctrl.get_render_window(),
+                        interactive_ratio=1,
+                    ) as vtk_view:
+                        ctrl.view_update = vtk_view.update
+                        ctrl.reset_camera = vtk_view.reset_camera
 
         # Footer
         # layout.footer.hide()

--- a/pan3d/viewer/ui.py
+++ b/pan3d/viewer/ui.py
@@ -16,29 +16,25 @@ def initialize(server):
             layout.toolbar.align = "center"
             vuetify.VSpacer()
 
-            vuetify.VCheckbox(
-                v_model=("view_edge_visiblity", True),
-                dense=True,
-                hide_details=True,
-                on_icon="mdi-border-all",
-                off_icon="mdi-border-outside",
-            )
-
-            with vuetify.VBtn(
-                icon=True,
-                click=ctrl.reset,
-            ):
-                vuetify.VIcon("mdi-crop-free")
-
             vuetify.VSlider(
                 label="Resolution",
                 v_model=("resolution", 1.0),
+                v_show="array_active",
                 min=0.5,
                 max=1,
                 step=0.25,
                 hide_details=True,
                 dense=True,
                 style="max-width: 300px",
+            )
+
+            vuetify.VCheckbox(
+                v_model=("view_edge_visiblity", True),
+                v_show="array_active",
+                dense=True,
+                hide_details=True,
+                on_icon="mdi-border-all",
+                off_icon="mdi-border-outside",
             )
 
         # Drawer
@@ -81,6 +77,10 @@ def initialize(server):
 
         # Content
         with layout.content:
+            vuetify.VBanner(
+                "{{ error_message }}",
+                v_show=("error_message",),
+            )
             with html.Div(
                 classes="d-flex",
                 style="flex-direction: column; height: 100%",

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ packages = find:
 include_package_data = True
 install_requires =
     trame
+    trame-vuetify
+    trame-vtk
     vtk
     zarr
     netCDF4


### PR DESCRIPTION
- Move dataset selection box to sidebar
- Automatically select first available array once a dataset is ready
- Remove "reset view" button, automatically invoke reset on state changes
- Add error banner above render area to tell the user when/why an auto view reset fails
- Reorganize axis selection options to reduce redundant information