### PR TITLE
Vue 3 migration

### DIFF
--- a/pan3d/__main__.py
+++ b/pan3d/__main__.py
@@ -1,5 +1,5 @@
-from argparse import ArgumentParser
-from .dataset_builder import DatasetBuilder
+from argparse import ArgumentParser, BooleanOptionalAction
+from pan3d.dataset_builder import DatasetBuilder
 
 
 def main():
@@ -10,6 +10,7 @@ def main():
 
     parser.add_argument("-b", "--config_path")
     parser.add_argument("-d", "--dataset_path")
+    parser.add_argument("-s", "--server", action=BooleanOptionalAction)
 
     args = parser.parse_args()
 
@@ -17,3 +18,7 @@ def main():
     if args.config_path:
         builder.import_config(args.config_path)
     builder.viewer.server.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/pan3d/__main__.py
+++ b/pan3d/__main__.py
@@ -1,18 +1,19 @@
-import argparse
-from dataset_builder import DatasetBuilder
+from argparse import ArgumentParser
+from .dataset_builder import DatasetBuilder
 
-parser = argparse.ArgumentParser(
-    prog="Pan3D",
-    description="Launch the Pan3D Dataset Builder",
-)
 
-parser.add_argument("-b", "--config_path")
-parser.add_argument("-d", "--dataset_path")
-parser.add_argument("-s", "--server", action=argparse.BooleanOptionalAction)
+def main():
+    parser = ArgumentParser(
+        prog="Pan3D",
+        description="Launch the Pan3D Dataset Builder",
+    )
 
-args = parser.parse_args()
+    parser.add_argument("-b", "--config_path")
+    parser.add_argument("-d", "--dataset_path")
 
-builder = DatasetBuilder(dataset_path=args.dataset_path)
-if args.config_path:
-    builder.import_config(args.config_path)
-builder.viewer.server.start(open_browser=not args.server)
+    args = parser.parse_args()
+
+    builder = DatasetBuilder(dataset_path=args.dataset_path)
+    if args.config_path:
+        builder.import_config(args.config_path)
+    builder.viewer.server.start()

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -6,9 +6,10 @@ from pvxarray.vtk_source import PyVistaXarraySource
 from pyvista.trame.ui import plotter_ui
 
 from trame.decorators import TrameApp, change
-from trame.ui.vuetify import SinglePageWithDrawerLayout  # TODO: upgrade to vuetify 3
+from trame.ui.vuetify3 import SinglePageWithDrawerLayout
 from trame.app import get_server
-from trame.widgets import html, vuetify
+from trame.widgets import html, client
+from trame.widgets import vuetify3 as vuetify
 
 from pan3d.ui import AxisSelection, MainDrawer, Toolbar
 from pan3d.utils import initial_state, run_singleton_task
@@ -24,7 +25,7 @@ class DatasetBuilder:
             server = get_server(server)
 
         # Fix version of vue
-        server.client_type = "vue2"  # TODO: upgrade to vue3
+        server.client_type = "vue3"
         self.server = server
         self._layout = None
 
@@ -63,10 +64,10 @@ class DatasetBuilder:
             # Build UI
             self._layout = SinglePageWithDrawerLayout(self.server)
             with self._layout as layout:
+                client.Style(open("pan3d/ui/custom.css").read())
                 layout.title.set_text("Pan3D Viewer")
                 layout.footer.hide()
                 with layout.toolbar:
-                    layout.toolbar.dense = True
                     layout.toolbar.align = "center"
                     Toolbar(reset=self.ctrl.reset)
                 with layout.drawer:
@@ -74,7 +75,7 @@ class DatasetBuilder:
                 with layout.content:
                     with html.Div(
                         v_show="array_active",
-                        style="height: 100%; position: relative; width: calc(100% - 300px)",
+                        style="height: 100%; position: relative;",
                     ):
                         vuetify.VBanner(
                             "{{ error_message }}",
@@ -172,6 +173,11 @@ class DatasetBuilder:
         if len(self.state.data_attrs) > 0:
             self.state.show_data_attrs = True
         self.state.coordinates = []
+        self.state.x_array = None
+        self.state.y_array = None
+        self.state.z_array = None
+        self.state.t_array = None
+        self.state.t_index = 0
         self.state.dataset_ready = True
         if len(self.state.data_vars) > 0:
             self.state.array_active = self.state.data_vars[0]["name"]

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -176,11 +176,9 @@ class DatasetBuilder:
         if len(self.state.data_attrs) > 0:
             self.state.show_data_attrs = True
         self.state.coordinates = []
-        self.state.x_array = None
-        self.state.y_array = None
-        self.state.z_array = None
-        self.state.t_array = None
-        self.state.t_index = 0
+        self.state.update(
+            dict(x_array=None, y_array=None, z_array=None, t_array=None, t_index=0)
+        )
         self.state.dataset_ready = True
         if len(self.state.data_vars) > 0:
             self.state.array_active = self.state.data_vars[0]["name"]

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -15,7 +15,8 @@ from trame.widgets import vuetify3 as vuetify
 from pan3d.ui import AxisSelection, MainDrawer, Toolbar
 from pan3d.utils import initial_state, run_singleton_task
 
-DIR = os.path.dirname(os.path.realpath(__file__))
+BASE_DIR = Path(__file__).parent
+CSS_FILE = BASE_DIR / "ui" / "custom.css"
 
 
 @TrameApp()
@@ -67,7 +68,7 @@ class DatasetBuilder:
             # Build UI
             self._layout = SinglePageWithDrawerLayout(self.server)
             with self._layout as layout:
-                client.Style(open(Path(DIR, "ui/custom.css")).read())
+                client.Style(CSS_FILE.read_text())
                 layout.title.set_text("Pan3D Viewer")
                 layout.footer.hide()
                 with layout.toolbar:

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -14,6 +14,8 @@ from trame.widgets import vuetify3 as vuetify
 from pan3d.ui import AxisSelection, MainDrawer, Toolbar
 from pan3d.utils import initial_state, run_singleton_task
 
+DIR = os.path.dirname(os.path.realpath(__file__))
+
 
 @TrameApp()
 class DatasetBuilder:
@@ -64,7 +66,7 @@ class DatasetBuilder:
             # Build UI
             self._layout = SinglePageWithDrawerLayout(self.server)
             with self._layout as layout:
-                client.Style(open("pan3d/ui/custom.css").read())
+                client.Style(open(f"{DIR}/ui/custom.css").read())
                 layout.title.set_text("Pan3D Viewer")
                 layout.footer.hide()
                 with layout.toolbar:

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -2,6 +2,7 @@ import json
 import os
 import pyvista
 import xarray
+from pathlib import Path
 from pvxarray.vtk_source import PyVistaXarraySource
 from pyvista.trame.ui import plotter_ui
 
@@ -66,7 +67,7 @@ class DatasetBuilder:
             # Build UI
             self._layout = SinglePageWithDrawerLayout(self.server)
             with self._layout as layout:
-                client.Style(open(f"{DIR}/ui/custom.css").read())
+                client.Style(open(Path(DIR, "ui/custom.css")).read())
                 layout.title.set_text("Pan3D Viewer")
                 layout.footer.hide()
                 with layout.toolbar:

--- a/pan3d/ui/axis_configure.py
+++ b/pan3d/ui/axis_configure.py
@@ -1,4 +1,4 @@
-from trame.widgets import vuetify
+from trame.widgets import vuetify3 as vuetify
 
 
 class AxisConfigure(vuetify.VCard):
@@ -21,16 +21,16 @@ class AxisConfigure(vuetify.VCard):
 
         with self:
             # Open expansion panel by default
-            with vuetify.VExpansionPanels(value=([0],), accordion=True):
+            with vuetify.VExpansionPanels(model_value=([0],), accordion=True):
                 with vuetify.VExpansionPanel():
-                    vuetify.VExpansionPanelHeader("{{ %s }}" % (name_var or name,))
-                    with vuetify.VExpansionPanelContent():
+                    vuetify.VExpansionPanelTitle("{{ %s }}" % (name_var or name,))
+                    with vuetify.VExpansionPanelText():
                         with vuetify.VSelect(
                             label="Assign axis",
                             items=(axes,),
-                            item_text="label",
+                            item_title="label",
                             item_value="name_var",
-                            value=name_var or "undefined",
+                            model_value=(name_var or "undefined",),
                             clearable=True,
                             click_clear=(
                                 coordinate_select_axis,
@@ -43,21 +43,18 @@ class AxisConfigure(vuetify.VCard):
                             # if this change is not prevented, the select maintains the last input
                             # if this card becomes visible again
                             with vuetify.Template(
-                                v_slot_item="{ attrs, item, parent }"
+                                v_slot_item="{ props, item, parent }"
                             ):
-                                with vuetify.VListItem(
-                                    v_bind="attrs",
+                                vuetify.VListItem(
+                                    v_bind="props",
+                                    title="{{ props.title }}",
                                     click=(
                                         coordinate_select_axis,
                                         # args: coord name, current axis, new axis
                                         f"""[
                                             {name_var or name or "undefined"},
                                             '{name_var or "undefined"}',
-                                            item.name_var
+                                            props.value
                                         ]""",
-                                        # make selection dropdown disappear
-                                        "parent.$el.style.display = 'none'",
                                     ),
-                                ):
-                                    with vuetify.VListItemContent():
-                                        vuetify.VListItemTitle("{{ item.label }}")
+                                )

--- a/pan3d/ui/axis_selection.py
+++ b/pan3d/ui/axis_selection.py
@@ -1,4 +1,5 @@
-from trame.widgets import html, vuetify
+from trame.widgets import html
+from trame.widgets import vuetify3 as vuetify
 from .axis_configure import AxisConfigure
 
 
@@ -16,10 +17,10 @@ class AxisSelection(vuetify.VNavigationDrawer):
         t_max="t_max",
     ):
         super().__init__(
-            value=(array_active,),
+            model_value=(array_active,),
             classes="pa-2",
             width="300",
-            right=True,
+            location="right",
             permanent=True,
             style="position: absolute",
         )
@@ -51,11 +52,10 @@ class AxisSelection(vuetify.VNavigationDrawer):
         ]
         with self:
             with vuetify.VExpansionPanels(
-                value=([0, 1],), multiple=True, accordion=True
+                model_value=([0, 1],), multiple=True, accordion=True
             ):
-                with vuetify.VExpansionPanel():
-                    vuetify.VExpansionPanelHeader("Assigned Coordinates")
-                    with vuetify.VExpansionPanelContent():
+                with vuetify.VExpansionPanel(title="Assigned Coordinates"):
+                    with vuetify.VExpansionPanelText():
                         for axis in axes:
                             with vuetify.VSheet(classes="d-flex"):
                                 html.Span(axis["label"])
@@ -74,9 +74,8 @@ class AxisSelection(vuetify.VNavigationDrawer):
                                     height="40",
                                     classes="ml-3 mb-1",
                                 )
-                with vuetify.VExpansionPanel():
-                    vuetify.VExpansionPanelHeader("Available Coordinates")
-                    with vuetify.VExpansionPanelContent():
+                with vuetify.VExpansionPanel(title="Available Coordinates"):
+                    with vuetify.VExpansionPanelText():
                         with html.Div(
                             v_for="coord in coordinates",
                             v_show="![%s, %s, %s, %s].includes(coord.name)"

--- a/pan3d/ui/axis_selection.py
+++ b/pan3d/ui/axis_selection.py
@@ -89,9 +89,10 @@ class AxisSelection(vuetify.VNavigationDrawer):
                         html.Span(
                             "No coordinates remain.",
                             v_show="""
-                            coordinates.every(
-                                (c) => [%s, %s, %s, %s].includes(c.name)
-                            )
-                        """
+                                coordinates.every(
+                                    (c) => [%s, %s, %s, %s].includes(c.name)
+                                )
+                            """
                             % (x_array, y_array, z_array, t_array),
+                            classes="mx-5",
                         )

--- a/pan3d/ui/custom.css
+++ b/pan3d/ui/custom.css
@@ -1,0 +1,7 @@
+.v-expansion-panel-text__wrapper {
+    padding: 5px !important;
+}
+
+.v-expansion-panel--active>.v-expansion-panel-title {
+    min-height: 30px !important;
+}

--- a/pan3d/ui/main_drawer.py
+++ b/pan3d/ui/main_drawer.py
@@ -1,4 +1,5 @@
-from trame.widgets import html, vuetify
+from trame.widgets import html
+from trame.widgets import vuetify3 as vuetify
 
 
 class MainDrawer(html.Div):
@@ -23,12 +24,9 @@ class MainDrawer(html.Div):
                 label="Choose a dataset",
                 v_model=dataset_path,
                 items=(available_datasets,),
-                item_text="name",
+                item_title="name",
                 item_value="url",
-                hide_details=True,
-                dense=True,
-                outlined=True,
-                classes="pt-1",
+                density="compact",
             )
 
             html.A(
@@ -47,39 +45,33 @@ class MainDrawer(html.Div):
                 "No data variables found.",
                 v_show=(f"{dataset_ready} && {data_vars}.length === 0",),
             )
-            with vuetify.VTreeview(
+            vuetify.VList(
                 v_show=dataset_ready,
-                dense=True,
-                activatable=True,
-                active=(f"[{array_active}]",),
-                items=(data_vars,),
-                item_key="name",
-                update_active=f"""
-                            {array_active} = $event[0];
-                            {x_array} = null;
-                            {y_array} = null;
-                            {z_array} = null;
-                            {t_array} = null;
-                            {t_index} = 0;
-                        """,
-                multiple_active=False,
-            ):
-                with vuetify.Template(v_slot_label="{ item }"):
-                    html.Span("{{ item?.name }}", classes="text-subtitle-2")
-
-            attrs_headers = [
-                {"text": "key", "value": "key"},
-                {"text": "value", "value": "value"},
-            ]
+                items=(f"{data_vars}",),
+                item_title="name",
+                item_value="name",
+                selected=(f"[{array_active}]",),
+                update_selected=f"""
+                    {array_active} = $event[0];
+                    {x_array} = undefined;
+                    {y_array} = undefined;
+                    {z_array} = undefined;
+                    {t_array} = undefined;
+                    {t_index} = 0;
+                """,
+            )
             vuetify.VCardText(
                 "Data Attributes",
                 v_show=f"{data_attrs}.length",
                 classes="font-weight-bold",
             )
-            vuetify.VDataTable(
-                v_show=f"{data_attrs}.length",
-                dense=True,
-                items=(data_attrs,),
-                headers=("headers", attrs_headers),
-                hide_default_header=True,
-            )
+            with vuetify.VTable(
+                v_show=f"{dataset_ready} && {data_attrs}.length",
+                density="compact",
+            ):
+                with html.Tbody():
+                    with html.Tr(
+                        v_for=f"data_attr in {data_attrs}",
+                    ):
+                        html.Td("{{ data_attr.key }}")
+                        html.Td("{{ data_attr.value }}")

--- a/pan3d/ui/toolbar.py
+++ b/pan3d/ui/toolbar.py
@@ -1,4 +1,5 @@
-from trame.widgets import html, vuetify
+from trame.widgets import html
+from trame.widgets import vuetify3 as vuetify
 
 
 class Toolbar(html.Div):
@@ -12,18 +13,18 @@ class Toolbar(html.Div):
         resolution="resolution",
         view_edge_visibility="view_edge_visibility",
     ):
-        super().__init__(style="width: 90%; display: flex")
+        super().__init__(
+            classes="d-flex flex-row-reverse pa-3 fill-height", style="column-gap: 10px"
+        )
         with self:
             vuetify.VProgressCircular(
                 v_show=(loading,),
                 indeterminate=True,
                 classes="mx-10",
             )
-            vuetify.VSpacer()
             with vuetify.VBtn(
                 click=reset,
                 v_show=unapplied_changes,
-                classes="mr-5",
                 small=True,
             ):
                 html.Span("Apply & Render")
@@ -42,16 +43,13 @@ class Toolbar(html.Div):
                 v_model=(resolution, 1.0),
                 v_show=array_active,
                 items=(resolutions,),
-                hide_details=True,
-                dense=True,
-                style="max-width: 100px",
-                classes="mt-3",
+                density="compact",
+                style="width: 100px",
             )
             vuetify.VCheckbox(
                 v_model=(view_edge_visibility, True),
                 v_show=array_active,
-                dense=True,
-                hide_details=True,
-                on_icon="mdi-border-all",
-                off_icon="mdi-border-outside",
+                density="compact",
+                true_icon="mdi-border-all",
+                false_icon="mdi-border-outside",
             )

--- a/pan3d/ui/toolbar.py
+++ b/pan3d/ui/toolbar.py
@@ -44,7 +44,7 @@ class Toolbar(html.Div):
                 v_show=array_active,
                 items=(resolutions,),
                 density="compact",
-                style="width: 100px",
+                style="width: 150px",
             )
             vuetify.VCheckbox(
                 v_model=(view_edge_visibility, True),

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,9 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    pan3d-viewer = pan3d.viewer.__main__:main
+    pan3d-viewer = pan3d.__main__:main
 jupyter_serverproxy_servers =
-    pan3d-viewer = pan3d.viewer.jupyter:jupyter_proxy_info
+    pan3d-viewer = pan3d.jupyter:jupyter_proxy_info
 
 [semantic_release]
 version_pattern = setup.cfg:version = (\d+\.\d+\.\d+)


### PR DESCRIPTION
Before going too far on the Axis Selector redesign (#29) in Vue 2, I'd like to migrate to Vue 3 and use that API going forward. My pyvista PR was just merged (https://github.com/pyvista/pyvista/pull/4811), and a release will be going out soon.

This PR switches to the Vue 3 client type, and once the pyvista release is made, the pyvista `plotter_ui` function we use will return a compatible interface. 

** Requires pyvista >= 0.42.0 **