### PR TITLE
Allow other xarray engines for other file types

### DIFF
--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -133,10 +133,14 @@ class DatasetBuilder:
             ):
                 self.state.more_info_link = available_dataset["more_info"]
         if "https://" in dataset_path or os.path.exists(dataset_path):
-            # Assumes zarr store
+            engine = None
+            if ".zarr" in dataset_path:
+                engine = "zarr"
+            if ".nc" in dataset_path:
+                engine = "netcdf4"
             try:
                 self.dataset = xarray.open_dataset(
-                    dataset_path, engine="zarr", chunks={}
+                    dataset_path, engine=engine, chunks={}
                 )
             except Exception as e:
                 self.state.error_message = str(e)


### PR DESCRIPTION
I was able to test out the `pflotran` dataset from @johnkit, and I can confirm it works with Pan3D. We just need a few lines to support the `.nc` version of the data as well. 

![image](https://github.com/Kitware/pan3d/assets/44912689/62c1cd5c-27f7-4487-bb06-f012f83595e9)
