### PR TITLE
Update PyPI publishing

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -69,18 +69,22 @@ jobs:
       pytest,
     ]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      # https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#repurposing-of-version-and-publish-commands
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        uses: python-semantic-release/python-semantic-release@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          repository_username: __token__
-          repository_password: ${{ secrets.PYPI_API_TOKEN }}
-        working-directory: .
+
+      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
+        environment: release
+        permissions:
+          id-token: write


### PR DESCRIPTION
- Python semantic release has changed their API as of version 8 to no longer offer PyPI publishing. This PR follows their migration guide. https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html
- PyPI publishing is now done as a separate step using `pypa/gh-action-pypi-publish`, as recommended by the PyPI docs: https://docs.pypi.org/trusted-publishers/using-a-publisher/
- I have created a pending Trusted Publisher on my PyPI account, which is waiting for the first push from this repository to create the PyPI project.