### PR TITLE
Add UI panel to change render options

### DIFF
--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -446,7 +446,8 @@ class DatasetBuilder:
             **args,
         )
         self.plotter.view_isometric()
-        self.plotter.reset_camera()
+        self.ctrl.reset_camera()
+        self.ctrl.view_update()
 
     def reset(self, **kwargs):
         if not self.state.da_active:

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -446,6 +446,7 @@ class DatasetBuilder:
             **args,
         )
         self.plotter.view_isometric()
+        self.plotter.reset_camera()
 
     def reset(self, **kwargs):
         if not self.state.da_active:

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -225,7 +225,8 @@ class DatasetBuilder:
                 array_min = 0
                 array_max = int(da.coords[key].size)
             coord_attrs = [
-                {"key": str(k), "value": str(v)} for k, v in da.coords[key].attrs.items()
+                {"key": str(k), "value": str(v)}
+                for k, v in da.coords[key].attrs.items()
             ]
             coord_attrs.append({"key": "dtype", "value": str(da.coords[key].dtype)})
             coord_attrs.append({"key": "length", "value": int(da.coords[key].size)})
@@ -296,10 +297,9 @@ class DatasetBuilder:
             zscale=self.state.render_z_scale or 1,
         )
 
-
     def set_render_options(
         self,
-        colormap='viridis',
+        colormap="viridis",
         transparency=False,
         transparency_function=None,
         scalar_warp=False,
@@ -345,14 +345,18 @@ class DatasetBuilder:
             self.state.state_export = self.export_config(None)
 
     @change("render_x_scale", "render_y_scale", "render_z_scale")
-    def _on_change_render_scales(self, render_x_scale, render_y_scale, render_z_scale, **kwargs):
-        self.set_render_scales(x=int(render_x_scale), y=int(render_y_scale), z=int(render_z_scale))
+    def _on_change_render_scales(
+        self, render_x_scale, render_y_scale, render_z_scale, **kwargs
+    ):
+        self.set_render_scales(
+            x=int(render_x_scale), y=int(render_y_scale), z=int(render_z_scale)
+        )
 
     @change(
         "render_colormap",
         "render_transparency",
         "render_transparency_function",
-        "render_scalar_warp"
+        "render_scalar_warp",
     )
     def _on_change_render_options(
         self,
@@ -360,13 +364,13 @@ class DatasetBuilder:
         render_transparency,
         render_transparency_function,
         render_scalar_warp,
-        **kwargs
+        **kwargs,
     ):
         self.set_render_options(
             colormap=render_colormap,
             transparency=render_transparency,
             transparency_function=render_transparency_function,
-            scalar_warp=render_scalar_warp
+            scalar_warp=render_scalar_warp,
         )
 
     # -----------------------------------------------------
@@ -432,7 +436,7 @@ class DatasetBuilder:
             scalar_bar_args=dict(interactive=True),
         )
         if self.state.render_transparency:
-            args['opacity'] = self.state.render_transparency_function
+            args["opacity"] = self.state.render_transparency_function
 
         mesh = self.mesh
         if self.state.render_scalar_warp:

--- a/pan3d/pangeo_forge.py
+++ b/pan3d/pangeo_forge.py
@@ -20,7 +20,7 @@ def get_catalog():
                     item_name = feedstock["spec"].split("/")[-1]
                     if len(data) > 1:
                         item_name += f' - {item["recipe_id"]}'
-                    if item_name not in [i['name'] for i in catalog]:
+                    if item_name not in [i["name"] for i in catalog]:
                         catalog.append(
                             {
                                 "name": item_name,

--- a/pan3d/ui/__init__.py
+++ b/pan3d/ui/__init__.py
@@ -1,6 +1,7 @@
 from .axis_drawer import AxisDrawer
 from .main_drawer import MainDrawer
 from .toolbar import Toolbar
+from .render_options import RenderOptions
 
 __all__ = [
     AxisDrawer,

--- a/pan3d/ui/__init__.py
+++ b/pan3d/ui/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     AxisDrawer,
     MainDrawer,
     Toolbar,
+    RenderOptions,
 ]

--- a/pan3d/ui/main_drawer.py
+++ b/pan3d/ui/main_drawer.py
@@ -19,7 +19,9 @@ class MainDrawer(vuetify.VNavigationDrawer):
         da_t="da_t",
         da_t_index="da_t_index",
     ):
-        super().__init__(v_model=ui_main_drawer, classes="pa-2", permanent=True, width=300)
+        super().__init__(
+            v_model=ui_main_drawer, classes="pa-2", permanent=True, width=300
+        )
         with self:
             vuetify.VSelect(
                 label="Choose a dataset",

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -1,8 +1,4 @@
-import json
-from trame.widgets import html, vuetify3 as vuetify
-from trame.app import get_server
-
-server = get_server()
+from trame.widgets import vuetify3 as vuetify
 
 
 class RenderOptions(vuetify.VMenu):

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -1,0 +1,89 @@
+import json
+from trame.widgets import html, vuetify3 as vuetify
+from trame.app import get_server
+
+server = get_server()
+
+
+class RenderOptions(vuetify.VMenu):
+    def __init__(
+        self,
+        x_scale="render_x_scale",
+        y_scale="render_y_scale",
+        z_scale="render_z_scale",
+        colormap="render_colormap",
+        colormap_options="render_colormap_options",
+        transparency="render_transparency",
+        transparency_function="render_transparency_function",
+        transparency_function_options="render_transparency_function_options",
+        scalar_warp="render_scalar_warp",
+    ):
+        super().__init__(
+            location="start",
+            transition="slide-y-transition",
+            close_on_content_click=False,
+        )
+        with self:
+            with vuetify.Template(
+                activator="{ props }",
+                __properties=[
+                ("activator", "v-slot:activator"),
+            ]):
+                vuetify.VBtn(
+                    v_bind="props",
+                    size="small",
+                    icon="mdi-dots-vertical",
+                    style="position: absolute; right: 20px; top: 20px; z-index:2"
+                )
+            with vuetify.VCard(classes="pa-3"):
+                vuetify.VSelect(
+                    label="Colormap",
+                    v_model=colormap,
+                    items=(colormap_options,),
+                    density="compact",
+                )
+                vuetify.VCheckbox(label="Transparency", v_model=transparency, density='compact')
+                vuetify.VSelect(
+                    label="Transparency Function",
+                    v_show=(transparency,),
+                    v_model=transparency_function,
+                    items=(transparency_function_options,),
+                    density="compact",
+                )
+                vuetify.VCheckbox(label="Warp by Scalars", v_model=scalar_warp, density='compact')
+                with vuetify.VContainer(
+                    classes="d-flex pa-0", style="column-gap: 3px"
+                ):
+                    vuetify.VTextField(
+                        v_model=x_scale,
+                        label="X Scale",
+                        min=1,
+                        step=1,
+                        hide_details=True,
+                        density="compact",
+                        style="width: 80px",
+                        type="number",
+                        __properties=["min", "step"],
+                    )
+                    vuetify.VTextField(
+                        v_model=y_scale,
+                        label="Y Scale",
+                        min=1,
+                        step=1,
+                        hide_details=True,
+                        density="compact",
+                        style="width: 80px",
+                        type="number",
+                        __properties=["min", "step"],
+                    )
+                    vuetify.VTextField(
+                        v_model=z_scale,
+                        label="Z Scale",
+                        min=1,
+                        step=1,
+                        hide_details=True,
+                        density="compact",
+                        style="width: 80px",
+                        type="number",
+                        __properties=["min", "step"],
+                    )

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -27,13 +27,14 @@ class RenderOptions(vuetify.VMenu):
             with vuetify.Template(
                 activator="{ props }",
                 __properties=[
-                ("activator", "v-slot:activator"),
-            ]):
+                    ("activator", "v-slot:activator"),
+                ],
+            ):
                 vuetify.VBtn(
                     v_bind="props",
                     size="small",
                     icon="mdi-dots-vertical",
-                    style="position: absolute; right: 20px; top: 20px; z-index:2"
+                    style="position: absolute; right: 20px; top: 20px; z-index:2",
                 )
             with vuetify.VCard(classes="pa-3"):
                 vuetify.VSelect(
@@ -42,7 +43,9 @@ class RenderOptions(vuetify.VMenu):
                     items=(colormap_options,),
                     density="compact",
                 )
-                vuetify.VCheckbox(label="Transparency", v_model=transparency, density='compact')
+                vuetify.VCheckbox(
+                    label="Transparency", v_model=transparency, density="compact"
+                )
                 vuetify.VSelect(
                     label="Transparency Function",
                     v_show=(transparency,),
@@ -50,10 +53,10 @@ class RenderOptions(vuetify.VMenu):
                     items=(transparency_function_options,),
                     density="compact",
                 )
-                vuetify.VCheckbox(label="Warp by Scalars", v_model=scalar_warp, density='compact')
-                with vuetify.VContainer(
-                    classes="d-flex pa-0", style="column-gap: 3px"
-                ):
+                vuetify.VCheckbox(
+                    label="Warp by Scalars", v_model=scalar_warp, density="compact"
+                )
+                with vuetify.VContainer(classes="d-flex pa-0", style="column-gap: 3px"):
                     vuetify.VTextField(
                         v_model=x_scale,
                         label="X Scale",

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -85,6 +85,39 @@ initial_state = {
     "ui_action_name": None,
     "ui_action_message": None,
     "ui_selected_config_file": None,
+    "render_x_scale": 1,
+    "render_y_scale": 1,
+    "render_z_scale": 1,
+    "render_scalar_warp": False,
+    "render_transparency": False,
+    "render_transparency_function": "linear",
+    "render_transparency_function_options": [
+        "linear",
+        "linear_r",
+        "geom",
+        "geom_r",
+        "sigmoid",
+        "sigmoid_r"
+    ],
+    "render_colormap": "viridis",
+    "render_colormap_options": [
+        "viridis",
+        "plasma",
+        "inferno",
+        "magma",
+        "terrain",
+        "ocean",
+        "cividis",
+        "seismic",
+        "rainbow",
+        "jet",
+        "turbo",
+        "gray",
+        "cool",
+        "hot",
+        "coolwarm",
+        "hsv",
+    ]
 }
 
 coordinate_auto_selection = {

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -97,7 +97,7 @@ initial_state = {
         "geom",
         "geom_r",
         "sigmoid",
-        "sigmoid_r"
+        "sigmoid_r",
     ],
     "render_colormap": "viridis",
     "render_colormap_options": [
@@ -117,7 +117,7 @@ initial_state = {
         "hot",
         "coolwarm",
         "hsv",
-    ]
+    ],
 }
 
 coordinate_auto_selection = {


### PR DESCRIPTION
New render options include:

- colormap
- transparency
- transparency function
- warp by scalars
- x scale
- y scale
- z scale

![image](https://github.com/Kitware/pan3d/assets/44912689/94218962-7ee6-4e6d-85fe-986188e94c96)

(Additionally, the colormap scale key is interactive; it can be resized and moved. This is functionality built into Pyvista.)