### PR TITLE
Fix PyPI publishing step in CI

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -81,10 +81,20 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
-      - name: Publish to PyPI
+  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+  publish:
+    needs: [
+      release,
+    ]
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: steps.release.outputs.released == 'true'
-        environment: release
-        permissions:
-          id-token: write


### PR DESCRIPTION
The CI config in #35 failed with the following:
```
The workflow is not valid. .github/workflows/test_and_release.yml (Line: 88, Col: 9): Unexpected value 'environment' .github/workflows/test_and_release.yml (Line: 89, Col: 9): Unexpected value 'permissions'
```

This PR changes the yml file by separating the PyPI publish step as its own job after the semantic release job. This time the job definition was pasted directly from the PyPI documentation.