### PR TITLE
Fix release job

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -63,6 +63,24 @@ jobs:
         pytest -s ./tests
       working-directory: .
 
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - run: python3 -m build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
   release:
     needs: [
       pre-commit,
@@ -84,6 +102,7 @@ jobs:
   # https://docs.pypi.org/trusted-publishers/using-a-publisher/
   publish:
     needs: [
+      build,
       release,
     ]
     name: Publish to PyPI
@@ -95,6 +114,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,7 +316,7 @@ Incorporate Pangeo Forge data ([`c589f69`](https://github.com/Kitware/pan3d/comm
 
 * Clear plotter on reset ([`da773c7`](https://github.com/Kitware/pan3d/commit/da773c776929e1e63dea3e4558efde4f39715e76))
 
-* Add dataset dimensions to data atrributes table ([`31c7136`](https://github.com/Kitware/pan3d/commit/31c713608dcd2400d6fa7ec7e4e3089acfed1245))
+* Add dataset dimensions to data attributes table ([`31c7136`](https://github.com/Kitware/pan3d/commit/31c713608dcd2400d6fa7ec7e4e3089acfed1245))
 
 * Correct label on Xarray examples ([`a5896fc`](https://github.com/Kitware/pan3d/commit/a5896fc634940e2468b6caab668e65da52aef9a2))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "pan3d"
+version = "1.0.0"
+description = "Utility package for processing and visualizing 3D datasets"
+authors = [
+    {name = "Kitware Inc."},
+]
+dependencies = [
+    "dask",
+    "fsspec",
+    "matplotlib",
+    "netCDF4",
+    "pyvista",
+    "pyvista-xarray",
+    "trame",
+    "trame-vtk",
+    "trame-vuetify",
+    "vtk",
+    "xarray",
+    "zarr",
+]
+requires-python = ">=3"
+readme = "README.rst"
+license = {text = "Apache Software License"}
+keywords = ["Python", "Interactive", "Web", "Application", "Framework"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Web Environment",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.scripts]
+pan3d-viewer = "pan3d.__main__:main"
+
+[project.entry-points.jupyter_serverproxy_servers]
+pan3d-viewer = "pan3d.jupyter:jupyter_proxy_info"
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.semantic_release]
+version_pattern = [
+    "setup.cfg:version = (\d+\.\d+\.\d+)",
+]


### PR DESCRIPTION
With #38, the semantic release step completed, but the following problems were identified:

- Version was set to 0.0.0, which means the version specification in `setup.cfg` was ignored. The cause was identified in the semantic-versioning v8 breaking changes. Configuration in `setup.cfg` is no longer supported (https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#setup-cfg-is-no-longer-supported). This PR adds a pyproject.toml file, which contains the same information as `setup.cfg`. Should we remove `setup.cfg`?
- The `CHANGELOG.md` file, which was pushed with the 0.0.0 release, contains all commit messages back to the first. One of those had a typo which caused a codespell error. This PR fixes the typo.

The PyPI release job that followed failed with the following:
```
Warning:  It looks like there are no Python distribution packages to publish in the directory 'dist/'. Please verify that they are in place should you face this problem.
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'  
```

This PR adds a job to the release workflow to build the dist folder prior to the pypi publish job.

