### PR TITLE
Use dynamic version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pan3d"
-version = "1.0.0"
+dynamic = ["version"]
 description = "Utility package for processing and visualizing 3D datasets"
 authors = [
     {name = "Kitware Inc."},


### PR DESCRIPTION
After merging #40, the PyPI publish action failed because the file for the "1.0.0" version exists already. The PyPI action is currently not using the git tag, it uses the static string in `pyproject.toml`. This PR changes that line to use dynamic versions from git tags. 

This fix was found here: https://stackoverflow.com/questions/72270892/git-versioning-with-setuptools-in-pyproject-toml