### PR TITLE
Add `vtk-osmesa` to requirements for binder

### DIFF
--- a/examples/jupyter/Dockerfile
+++ b/examples/jupyter/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/pyvista/pyvista:latest
+
+COPY . ${HOME}
+WORKDIR ${HOME}
+RUN pip install -r requirements.txt
+RUN pip uninstall vtk -y
+RUN pip install --extra-index-url https://wheels.vtk.org vtk-osmesa

--- a/examples/jupyter/requirements.txt
+++ b/examples/jupyter/requirements.txt
@@ -1,4 +1,2 @@
 pan3d
 imageio
---extra-index-url https://wheels.vtk.org
-vtk-osmesa

--- a/examples/jupyter/requirements.txt
+++ b/examples/jupyter/requirements.txt
@@ -1,2 +1,4 @@
 pan3d
 imageio
+--extra-index-url https://wheels.vtk.org
+vtk-osmesa

--- a/examples/jupyter/requirements.txt
+++ b/examples/jupyter/requirements.txt
@@ -1,2 +1,3 @@
 pan3d
 imageio
+trame-jupyter-extension


### PR DESCRIPTION
Currently, running the example notebooks on Binder gives the following error:
![image](https://github.com/Kitware/pan3d/assets/44912689/a720c15b-3b6a-4230-b250-ad12b33636c3)

This may be due to the fact that we should install `vtk-osmesa` in the binder kernel, so this PR makes that addition to `examples/jupyter/requirements.txt`.