### PR TITLE
Fix build versioning

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -63,32 +63,21 @@ jobs:
         pytest -s ./tests
       working-directory: .
 
-  build:
-    name: Build distribution
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
-    - run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - run: python3 -m build
-
   release:
     needs: [
-      build,
       pre-commit,
       pytest,
     ]
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-python@v4
 
       # https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#repurposing-of-version-and-publish-commands
       - name: Python Semantic Release
@@ -96,21 +85,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
-  publish:
-    needs: [
-      release,
-    ]
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - run: python3 -m pip install build --user
       - name: Build dist
         run: python3 -m build
+
+      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -76,13 +76,10 @@ jobs:
         build
         --user
     - run: python3 -m build
-    - uses: actions/upload-artifact@v3
-      with:
-        name: python-package-distributions
-        path: dist/
 
   release:
     needs: [
+      build,
       pre-commit,
       pytest,
     ]
@@ -102,7 +99,6 @@ jobs:
   # https://docs.pypi.org/trusted-publishers/using-a-publisher/
   publish:
     needs: [
-      build,
       release,
     ]
     name: Publish to PyPI
@@ -114,10 +110,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-
+      - name: Build dist
+        run: python3 -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,15 +41,14 @@ pan3d-viewer = "pan3d.__main__:main"
 pan3d-viewer = "pan3d.jupyter:jupyter_proxy_info"
 
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["pan3d", "pan3d.ui"]
 
-[tool.setuptools_scm]
-
 [tool.semantic_release]
+version_variables = ["setup.py:__version__"]
 version_pattern = [
     "setup.cfg:version = (\\d+\\.\\d+\\.\\d+)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,13 @@ pan3d-viewer = "pan3d.__main__:main"
 pan3d-viewer = "pan3d.jupyter:jupyter_proxy_info"
 
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["pan3d", "pan3d.ui"]
+
+[tool.setuptools_scm]
 
 [tool.semantic_release]
 version_pattern = [

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
 from setuptools import setup
 
-setup(include_package_data=True)
+__version__ = "0.1.1"
+
+setup(
+    name='pan3d',
+    include_package_data=True,
+    version=__version__,
+)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 __version__ = "0.1.1"
 
 setup(
-    name='pan3d',
+    name="pan3d",
     include_package_data=True,
     version=__version__,
 )


### PR DESCRIPTION
Currently, the build action always generates a tar and wheel for version 0.0.0. This results in a failure of the PyPI publish step because v0.0.0 already exists. This PR fixes the build step by adding `setuptools_scm` to `pyproject.toml`. The result should be that PyPI is updated with a version >0.0.0.