### PR TITLE
Client rendering fixes

### DIFF
--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -505,10 +505,7 @@ class DatasetBuilder:
             **args,
         )
         self.plotter.view_isometric()
-        if self._cloud:
-            self.ctrl.push_camera()
-        else:
-            self.ctrl.reset_camera()
+        self.ctrl.push_camera()
         self.ctrl.view_update()
 
     def reset(self, **kwargs):

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -37,6 +37,7 @@ class DatasetBuilder:
         server.client_type = "vue3"
         self.server = server
         self._layout = None
+        self._cloud = is_cloud_env()
 
         self.state.update(initial_state)
         self.algorithm = PyVistaXarraySource()
@@ -60,7 +61,7 @@ class DatasetBuilder:
         if state:
             self.state.update(state)
 
-        if is_cloud_env():
+        if self._cloud:
             pyvista.global_theme.trame.default_mode = "client"
 
     # -----------------------------------------------------
@@ -117,6 +118,7 @@ class DatasetBuilder:
                         ) as plot_view:
                             self.ctrl.view_update = plot_view.update
                             self.ctrl.reset_camera = plot_view.reset_camera
+                            self.ctrl.push_camera = plot_view.push_camera
         return self._layout
 
     # -----------------------------------------------------
@@ -370,7 +372,7 @@ class DatasetBuilder:
         if self.state.render_scalar_warp != scalar_warp:
             self.state.render_scalar_warp = scalar_warp
 
-        if self._mesh:
+        if self._mesh is not None and self.data_array is not None:
             self.plot_mesh()
 
     # -----------------------------------------------------
@@ -503,12 +505,17 @@ class DatasetBuilder:
             **args,
         )
         self.plotter.view_isometric()
-        self.ctrl.reset_camera()
+        if self._cloud:
+            self.ctrl.push_camera()
+        else:
+            self.ctrl.reset_camera()
         self.ctrl.view_update()
 
     def reset(self, **kwargs):
         if not self.state.da_active:
             return
+        if self.data_array is None:
+            self.mesh_changed()
         self.state.ui_error_message = None
         self.state.ui_loading = True
         self.state.ui_unapplied_changes = False

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -16,7 +16,7 @@ from trame.widgets import vuetify3 as vuetify
 from pan3d.ui import AxisDrawer, MainDrawer, Toolbar, RenderOptions
 from pan3d.utils import (
     initial_state,
-    is_cloud_env,
+    force_local_rendering,
     run_singleton_task,
     coordinate_auto_selection,
 )
@@ -37,7 +37,7 @@ class DatasetBuilder:
         server.client_type = "vue3"
         self.server = server
         self._layout = None
-        self._cloud = is_cloud_env()
+        self._force_local_rendering = force_local_rendering()
 
         self.state.update(initial_state)
         self.algorithm = PyVistaXarraySource()
@@ -61,7 +61,7 @@ class DatasetBuilder:
         if state:
             self.state.update(state)
 
-        if self._cloud:
+        if self._force_local_rendering:
             pyvista.global_theme.trame.default_mode = "client"
 
     # -----------------------------------------------------

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -16,7 +16,7 @@ from trame.widgets import vuetify3 as vuetify
 from pan3d.ui import AxisDrawer, MainDrawer, Toolbar, RenderOptions
 from pan3d.utils import (
     initial_state,
-    force_local_rendering,
+    has_gpu_rendering,
     run_singleton_task,
     coordinate_auto_selection,
 )
@@ -37,7 +37,7 @@ class DatasetBuilder:
         server.client_type = "vue3"
         self.server = server
         self._layout = None
-        self._force_local_rendering = force_local_rendering()
+        self._force_local_rendering = not has_gpu_rendering()
 
         self.state.update(initial_state)
         self.algorithm = PyVistaXarraySource()

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -51,9 +51,10 @@ def run_singleton_task(
     singleton_task = asyncio.run_coroutine_threadsafe(coroutine(), task_loop)
 
 
-def is_cloud_env():
-    cloud_env_vars = ["BINDER_REQUEST"]
-    return any(os.environ.get(k) for k in cloud_env_vars)
+def force_local_rendering():
+    # Prevent server-side rendering in certain environments
+    target_env_vars = ["BINDER_REQUEST"]
+    return any(os.environ.get(k) for k in target_env_vars)
 
 
 initial_state = {

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -51,10 +51,10 @@ def run_singleton_task(
     singleton_task = asyncio.run_coroutine_threadsafe(coroutine(), task_loop)
 
 
-def force_local_rendering():
-    # Prevent server-side rendering in certain environments
+def has_gpu_rendering():
+    # Detect known environments without gpu rendering
     target_env_vars = ["BINDER_REQUEST"]
-    return any(os.environ.get(k) for k in target_env_vars)
+    return not any(os.environ.get(k) for k in target_env_vars)
 
 
 initial_state = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pyvista",
     "pyvista-xarray",
     "trame",
-    "trame-vtk",
+    "trame-vtk>=2.6.3",
     "trame-vuetify",
     "vtk",
     "xarray",


### PR DESCRIPTION
This PR fixes the following errors we had been seeing:

1. `Uncaught TypeError: Cannot mix BigInt and other types, use explicit conversions`

- [x] Solution: require `trame-vtk>=2.6.3`. This version includes a fix by @jourdain to convert dtypes before meshing.

2. Initial camera reset not working in cloud environments where we set default rendering mode to "client"

- [x] Solution: use `plotter.push_camera` instead of `plotter.reset_camera` when cloud mode is enabled