### PR TITLE
Update example notebooks with catalogs argument

### DIFF
--- a/examples/jupyter/advanced_pyvista_rendering.ipynb
+++ b/examples/jupyter/advanced_pyvista_rendering.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "# Use Pan3D DatasetBuilder to import existing config file\n",
     "config_path = '../example_config_esgf.json'\n",
-    "builder = DatasetBuilder(esgf=True)\n",
+    "builder = DatasetBuilder(catalogs=['esgf'])\n",
     "builder.import_config(config_path)\n",
     "\n",
     "# Access PyVista Mesh on builder\n",
@@ -53,7 +53,7 @@
     "    plotter.clear()\n",
     "    builder.t_index = i\n",
     "    actor = plotter.add_mesh(builder.mesh.warp_by_scalar(), render=False, clim=[0, 22])\n",
-    "    \n",
+    "\n",
     "    # Write a frame. This triggers a render.\n",
     "    plotter.write_frame()\n",
     "\n",
@@ -62,6 +62,14 @@
     "\n",
     "# GIF generation takes about 2 mins for 420 frames (approximately 0.3 seconds to fetch and render each frame)\n",
     "print(f'Saved esgf.gif. Took {datetime.now() - start} seconds.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca246280-e8cd-44f2-b4a2-44a211116030",
+   "metadata": {},
+   "source": [
+    "![LocalGIF](esgf.gif \"gif\")"
    ]
   }
  ],

--- a/examples/jupyter/import_config_esgf.ipynb
+++ b/examples/jupyter/import_config_esgf.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "config_path = '../example_config_esgf.json'\n",
-    "builder = DatasetBuilder(esgf=True, viewer=True)\n",
+    "builder = DatasetBuilder(catalogs=['esgf'], viewer=True)\n",
     "\n",
     "builder.import_config(config_path)\n",
     "\n",

--- a/examples/jupyter/import_config_pangeo.ipynb
+++ b/examples/jupyter/import_config_pangeo.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "config_path = '../example_config_pangeo.json'\n",
-    "builder = DatasetBuilder(pangeo=True, viewer=True)\n",
+    "builder = DatasetBuilder(catalogs=['pangeo'], viewer=True)\n",
     "\n",
     "builder.import_config(config_path)\n",
     "\n",


### PR DESCRIPTION
This PR includes a change that should have been part of #67. Towards the end of that PR, we changed the API to specify which catalogs should be used. I should have updated the examples with that change. This PR includes one commit which modifies the jupyter notebook examples with the new `catalogs` argument . One small additional change is purely aesthetic: adding a markdown cell to `advanced_pyvista_rendering.ipynb` to show the GIF output.