### PR TITLE
Add cartographic rendering mode

### DIFF
--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -41,6 +41,7 @@ There are five sections available in the configuration file format: `data_origin
         "y_scale": 1,
         "z_scale": 1,
         "scalar_warp": false,
+        "cartographic": false,
         "transparency": false,
         "transparency_function": "linear",
         "colormap": "viridis"
@@ -106,6 +107,7 @@ The value for this key should be a mapping of any number of render state values.
 |`y_scale`|NO (default=1)|`int`|The relative scale of the Y axis in the rendered scene.|
 |`z_scale`|NO (default=1)|`int`|The relative scale of the Z axis in the rendered scene.|
 |`scalar_warp`|NO (default=False)|`bool`|If true, Apply scalar warping to the rendered mesh (extrude values in z-axis proportional to their magnitude).|
+|`cartographic`|NO (default=False)|`bool`|If true, render the data wrapped around an earth sphere.|
 |`transparency`|NO (default=False)|`bool`|If true, enable transparency mode for the rendered mesh, applying the current transparency function.|
 |`transparency_function`|NO (default="linear")|`str`|The name of the transparency function to apply when transparency is enabled. Options are "linear", "linear_r", "geom", "geom_r", "sigmoid", and "sigmoid_r".|
 |`colormap`|NO (default="viridis")|`str`|The name of the colormap to apply to the rendered mesh. Any matplotlib colormap name is a valid value.|

--- a/docs/tutorials/dataset_viewer.md
+++ b/docs/tutorials/dataset_viewer.md
@@ -197,6 +197,7 @@ For our configuration, the contents of the exported file appear as follows:
         "y_scale": 2,
         "z_scale": 1,
         "scalar_warp": true,
+        "cartographic": false,
         "transparency": true,
         "transparency_function": "linear_r",
         "colormap": "plasma"

--- a/examples/example_config_esgf.json
+++ b/examples/example_config_esgf.json
@@ -42,6 +42,7 @@
         "y_scale": 1,
         "z_scale": 1,
         "scalar_warp": false,
+        "cartographic": false,
         "transparency": false,
         "transparency_function": "linear",
         "colormap": "cividis"

--- a/examples/example_config_noaa.json
+++ b/examples/example_config_noaa.json
@@ -23,5 +23,8 @@
         "main_drawer": false,
         "axis_drawer": false,
         "expanded_coordinates": []
+    },
+    "render": {
+        "cartographic": true
     }
 }

--- a/examples/example_config_pangeo.json
+++ b/examples/example_config_pangeo.json
@@ -48,6 +48,7 @@
         "y_scale": 1,
         "z_scale": 100,
         "scalar_warp": false,
+        "cartographic": false,
         "transparency": false,
         "transparency_function": "linear",
         "colormap": "viridis"

--- a/pan3d/dataset_builder.py
+++ b/pan3d/dataset_builder.py
@@ -331,16 +331,9 @@ class DatasetBuilder:
             for key, value in slicing.items():
                 if not isinstance(key, str):
                     raise ValueError("Keys in slicing must be strings.")
-                if (
-                    not isinstance(value, list)
-                    or len(value) != 3
-                    or any(
-                        not isinstance(v, int) and not isinstance(v, float)
-                        for v in value
-                    )
-                ):
+                if not isinstance(value, list) or len(value) != 3:
                     raise ValueError(
-                        "Values in slicing must be lists of three integers ([start, stop, step])."
+                        "Values in slicing must be lists of length 3 ([start, stop, step])."
                     )
                 acceptable_coords = self.dataset[self.data_array_name].coords
                 if key not in acceptable_coords:

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -309,6 +309,7 @@ class DatasetViewer:
         transparency: bool = False,
         transparency_function: str = None,
         scalar_warp: bool = False,
+        cartographic: bool = False,
     ) -> None:
         """Set available options for rendering data.
 
@@ -317,6 +318,7 @@ class DatasetViewer:
             transparency: If true, enable transparency and use transparency_function.
             transparency_function: One of PyVista's opacity transfer functions (https://docs.pyvista.org/version/stable/examples/02-plot/opacity.html#transfer-functions)
             scalar_warp: If true, warp the mesh proportional to its scalars.
+            cartographic: If true, wrap the mesh around an earth sphere.
         """
         if self.state.render_colormap != colormap:
             self.state.render_colormap = colormap
@@ -326,6 +328,8 @@ class DatasetViewer:
             self.state.render_transparency_function = transparency_function
         if self.state.render_scalar_warp != scalar_warp:
             self.state.render_scalar_warp = scalar_warp
+        if self.state.render_cartographic != cartographic:
+            self.state.render_cartographic = cartographic
 
         if self.builder.mesh is not None and self.builder.data_array is not None:
             self.apply_and_render()
@@ -348,6 +352,8 @@ class DatasetViewer:
 
         if self.state.render_scalar_warp:
             mesh = mesh.warp_by_scalar()
+        if self.state.render_cartographic:
+            pass
         self.actor = self.plotter.add_mesh(
             mesh,
             **args,
@@ -674,6 +680,7 @@ class DatasetViewer:
         "render_transparency",
         "render_transparency_function",
         "render_scalar_warp",
+        "render_cartographic",
     )
     def _on_change_render_options(
         self,
@@ -681,6 +688,7 @@ class DatasetViewer:
         render_transparency,
         render_transparency_function,
         render_scalar_warp,
+        render_cartographic,
         **kwargs,
     ):
         self.set_render_options(
@@ -688,4 +696,5 @@ class DatasetViewer:
             transparency=render_transparency,
             transparency_function=render_transparency_function,
             scalar_warp=render_scalar_warp,
+            cartographic=render_cartographic,
         )

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -364,6 +364,12 @@ class DatasetViewer:
                 da,
             )
             mesh = mesh.threshold()  # make NaN values transparent
+
+            # position camera
+            camera = self.plotter.camera
+            camera.focal_point = [0, 0, 0]
+            camera.position = mesh.center
+            self.plotter.reset_camera(bounds=mesh.bounds)
         else:
             mesh = self.builder.mesh
 
@@ -375,11 +381,8 @@ class DatasetViewer:
         )
         if len(self.builder.data_array.shape) > 2:
             self.plotter.view_isometric()
-        else:
-            if self.state.render_cartographic:
-                self.plotter.view_xz()
-            else:
-                self.plotter.view_xy()
+        elif not self.state.render_cartographic:
+            self.plotter.view_xy()
 
         if self.plot_view:
             self.ctrl.push_camera()

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -355,7 +355,7 @@ class DatasetViewer:
             mesh = geovista.Transform.from_1d(
                 da[self.builder.x],  # lon coordinates
                 da[self.builder.y],  # lat coordinates
-                da
+                da,
             )
             mesh = mesh.threshold()  # make NaN values transparent
         else:

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -311,6 +311,7 @@ class DatasetViewer:
         transparency_function: str = None,
         scalar_warp: bool = False,
         cartographic: bool = False,
+        render: bool = True,
     ) -> None:
         """Set available options for rendering data.
 
@@ -320,6 +321,7 @@ class DatasetViewer:
             transparency_function: One of PyVista's opacity transfer functions (https://docs.pyvista.org/version/stable/examples/02-plot/opacity.html#transfer-functions)
             scalar_warp: If true, warp the mesh proportional to its scalars.
             cartographic: If true, wrap the mesh around an earth sphere.
+            render: If true, update current render with new values (default=True)
         """
         if self.state.render_colormap != colormap:
             self.state.render_colormap = colormap
@@ -332,7 +334,11 @@ class DatasetViewer:
         if self.state.render_cartographic != cartographic:
             self.state.render_cartographic = cartographic
 
-        if self.builder.mesh is not None and self.builder.data_array is not None:
+        if (
+            render
+            and self.builder.mesh is not None
+            and self.builder.data_array is not None
+        ):
             self.apply_and_render()
 
     def plot_mesh(self) -> None:

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -422,6 +422,8 @@ class DatasetViewer:
                 if loading_state is not None:
                     self.state[loading_state] = False
 
+            await asyncio.sleep(0.001)
+
         if self.current_event_loop.is_running():
             asyncio.run_coroutine_threadsafe(run(), self.current_event_loop)
         else:

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -13,6 +13,7 @@ class RenderOptions(vuetify.VMenu):
         transparency_function="render_transparency_function",
         transparency_function_options="render_transparency_function_options",
         scalar_warp="render_scalar_warp",
+        cartographic="render_cartographic",
     ):
         super().__init__(
             location="start",
@@ -51,6 +52,9 @@ class RenderOptions(vuetify.VMenu):
                 )
                 vuetify.VCheckbox(
                     label="Warp by Scalars", v_model=(scalar_warp,), density="compact"
+                )
+                vuetify.VCheckbox(
+                    label="Cartographic", v_model=(cartographic,), density="compact"
                 )
                 with vuetify.VContainer(classes="d-flex pa-0", style="column-gap: 3px"):
                     vuetify.VTextField(

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -50,11 +50,18 @@ class RenderOptions(vuetify.VMenu):
                     items=(transparency_function_options,),
                     density="compact",
                 )
+                # Scalar warp mode and cartographic mode are mutually exclusive
                 vuetify.VCheckbox(
-                    label="Warp by Scalars", v_model=(scalar_warp,), density="compact"
+                    label="Warp by Scalars",
+                    v_model=(scalar_warp,),
+                    disabled=(cartographic,),
+                    density="compact",
                 )
                 vuetify.VCheckbox(
-                    label="Cartographic", v_model=(cartographic,), density="compact"
+                    label="Cartographic",
+                    v_model=(cartographic,),
+                    disabled=(scalar_warp,),
+                    density="compact",
                 )
                 with vuetify.VContainer(classes="d-flex pa-0", style="column-gap: 3px"):
                     vuetify.VTextField(

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -83,6 +83,7 @@ initial_state = {
     "render_y_scale": 1,
     "render_z_scale": 1,
     "render_scalar_warp": False,
+    "render_cartographic": False,
     "render_transparency": False,
     "render_transparency_function": "linear",
     "render_transparency_function_options": [

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -65,6 +65,7 @@ initial_state = {
     "da_t_index": 0,
     "da_size": None,
     "ui_loading": False,
+    "ui_import_loading": False,
     "ui_main_drawer": False,
     "ui_axis_drawer": False,
     "ui_unapplied_changes": False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ viewer = [
     "trame>=3.5",
     "trame-vtk>=2.6",
     "trame-vuetify>=2.4",
+    "geovista>=0.4",
 ]
 esgf = [
     "intake-esgf>=2024.1",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -183,7 +183,7 @@ def test_setters_invalid_values():
         builder.slicing = {"foo": []}
     assert (
         str(e.value)
-        == "Values in slicing must be lists of three integers ([start, stop, step])."
+        == "Values in slicing must be lists of length 3 ([start, stop, step])."
     )
     with pytest.raises(ValueError) as e:
         builder.slicing = {"foo": [0, 1, 1]}

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -94,6 +94,7 @@ def test_render_options_state():
         transparency=True,
         transparency_function="linear_r",
         scalar_warp=True,
+        cartographic=True,
     )
 
     assert viewer.state.render_x_scale == 2
@@ -103,6 +104,7 @@ def test_render_options_state():
     assert viewer.state.render_transparency
     assert viewer.state.render_transparency_function == "linear_r"
     assert viewer.state.render_scalar_warp
+    assert viewer.state.render_cartographic
 
 
 def test_viewer_export():

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -13,11 +13,7 @@ def push_builder_state(builder):
 def push_viewer_state(viewer):
     # For state updates with callbacks,
     # Ensure the callbacks occur in the correct order
-    viewer.state.update(
-        dict(
-            dataset_info={"source": "xarray", "id": "eraint_uvz"},
-        )
-    )
+    viewer.state.update(dict(dataset_info={"source": "xarray", "id": "eraint_uvz"}))
     viewer.state.flush()
     viewer.state.update(
         dict(
@@ -95,6 +91,9 @@ def test_render_options_state():
         transparency_function="linear_r",
         scalar_warp=True,
         cartographic=False,  # not compatible with this 4D data
+        # geovista GeoPlotter includes a check for GPU availability,
+        # which fails on GH Actions. Disable render in this function.
+        render=False,
     )
 
     assert viewer.state.render_x_scale == 2
@@ -104,7 +103,7 @@ def test_render_options_state():
     assert viewer.state.render_transparency
     assert viewer.state.render_transparency_function == "linear_r"
     assert viewer.state.render_scalar_warp
-    assert viewer.state.render_cartographic
+    assert not viewer.state.render_cartographic
 
 
 def test_viewer_export():

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -94,7 +94,7 @@ def test_render_options_state():
         transparency=True,
         transparency_function="linear_r",
         scalar_warp=True,
-        cartographic=True,
+        cartographic=False,  # not compatible with this 4D data
     )
 
     assert viewer.state.render_x_scale == 2


### PR DESCRIPTION
Resolves #18.

This PR adds a flag "render_cartographic" to the `DatasetViewer` state. When enabled, the current data will be rendered on the surface of a sphere with an earth texture. To accomplish this, we now use a `GeoPlotter` from the `geovista` library, which inherits from `pyvista.Plotter`. This PR adds `geovista` to the dependencies for the viewer.

The video below shows basic usage of the cartographic flag:
https://github.com/Kitware/pan3d/assets/44912689/ae8b9dd0-124f-42b2-b4be-6aef0e5638a9

Edit: This PR also includes one semi-unrelated chage; the dataset I tested this feature on was incompatible with the type checking implemented in #70. I removed the check for numeric typing on the values in a slicing array, because we should allow strings for start and stop values of time axes.

