### PR TITLE
Remove shorthand notations of cmdline args

### DIFF
--- a/docs/tutorials/command_line.md
+++ b/docs/tutorials/command_line.md
@@ -16,9 +16,9 @@ There are other arguments to initialize features and data. Here is the full list
 
 ```bash
 --help/-h:        Write command info including the list of options to the terminal and exit.
---server/-S:      Launch in server mode, which disables the default behavior of opening a browser tab on startup.
---dataset/-D:     Pass a string with this argument to specify a target dataset. This value can be either a local path or remote URL. This value must be readable by `xarray.open_dataset()`.
---config_path/-C: Pass a string with this argument to specify a startup configuration. This value must be a local path to a JSON file which adheres to the schema specified in the [Configuration Files documentation](../api/configuration.md). A dataset specified in this configuration will override any value passed to `--dataset`/`-D`.
---catalogs/-c:    Pass one or more strings which reference available catalog modules (options include "pangeo", "esgf"). If specified, the Catalog Search interface will become available in the left sidebar. See the Catalog Search Tutorial for more information.
---debug/-d:       Launch in debug mode, which will include more terminal output. Intended for developer use.
+--server:      Launch in server mode, which disables the default behavior of opening a browser tab on startup.
+--dataset:     Pass a string with this argument to specify a target dataset. This value can be either a local path or remote URL. This value must be readable by `xarray.open_dataset()`.
+--config_path: Pass a string with this argument to specify a startup configuration. This value must be a local path to a JSON file which adheres to the schema specified in the [Configuration Files documentation](../api/configuration.md). A dataset specified in this configuration will override any value passed to `--dataset`.
+--catalogs:    Pass one or more strings which reference available catalog modules (options include "pangeo", "esgf"). If specified, the Catalog Search interface will become available in the left sidebar. See the Catalog Search Tutorial for more information.
+--debug:       Launch in debug mode, which will include more terminal output. Intended for developer use.
 ```

--- a/pan3d/serve_viewer.py
+++ b/pan3d/serve_viewer.py
@@ -8,11 +8,11 @@ def serve():
         description="Launch the Pan3D Dataset Viewer",
     )
 
-    parser.add_argument("-C", "--config_path")
-    parser.add_argument("-D", "--dataset")
-    parser.add_argument("-c", "--catalogs", nargs="+")
-    parser.add_argument("-S", "--server", action=BooleanOptionalAction)
-    parser.add_argument("-d", "--debug", action=BooleanOptionalAction)
+    parser.add_argument("--config_path")
+    parser.add_argument("--dataset")
+    parser.add_argument("--catalogs", nargs="+")
+    parser.add_argument("--server", action=BooleanOptionalAction)
+    parser.add_argument("--debug", action=BooleanOptionalAction)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Resolves #75 