### PR TITLE
Fix menu/drawer overlap bug

### DIFF
--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -839,3 +839,11 @@ class DatasetViewer:
     @change("cube_view_mode", "cube_preview_face")
     def _on_change_cube_view(self, cube_view_mode, cube_preview_face, **kwargs):
         self._generate_preview()
+
+    @change("ui_main_drawer")
+    def _on_change_ui_main_drawer(self, ui_main_drawer, **kwargs):
+        self.state.ui_bounds_menu = False
+
+    @change("ui_axis_drawer")
+    def _on_change_ui_axis_drawer(self, ui_axis_drawer, **kwargs):
+        self.state.ui_render_options_menu = False

--- a/pan3d/ui/bounds_configure.py
+++ b/pan3d/ui/bounds_configure.py
@@ -20,7 +20,7 @@ class BoundsConfigure(vuetify.VMenu):
         cube_preview_face="cube_preview_face",
         cube_preview_face_options="cube_preview_face_options",
         cube_preview_axes="cube_preview_axes",
-        ui_bounds_menu="ui_bounds_menu"
+        ui_bounds_menu="ui_bounds_menu",
     ):
         super().__init__(
             v_model=(ui_bounds_menu,),

--- a/pan3d/ui/bounds_configure.py
+++ b/pan3d/ui/bounds_configure.py
@@ -20,10 +20,12 @@ class BoundsConfigure(vuetify.VMenu):
         cube_preview_face="cube_preview_face",
         cube_preview_face_options="cube_preview_face_options",
         cube_preview_axes="cube_preview_axes",
+        ui_bounds_menu="ui_bounds_menu"
     ):
         super().__init__(
+            v_model=(ui_bounds_menu,),
             location="start",
-            transition="slide-y-transition",
+            transition="slide-x-transition",
             close_on_content_click=False,
             persistent=True,
             no_click_animation=True,

--- a/pan3d/ui/render_options.py
+++ b/pan3d/ui/render_options.py
@@ -14,10 +14,12 @@ class RenderOptions(vuetify.VMenu):
         transparency_function_options="render_transparency_function_options",
         scalar_warp="render_scalar_warp",
         cartographic="render_cartographic",
+        ui_render_options_menu="ui_render_options_menu",
     ):
         super().__init__(
+            v_model=(ui_render_options_menu,),
             location="start",
-            transition="slide-y-transition",
+            transition="slide-x-transition",
             close_on_content_click=False,
             persistent=True,
             no_click_animation=True,

--- a/pan3d/utils.py
+++ b/pan3d/utils.py
@@ -74,6 +74,8 @@ initial_state = {
     "ui_import_loading": False,
     "ui_main_drawer": False,
     "ui_axis_drawer": False,
+    "ui_bounds_menu": False,
+    "ui_render_options_menu": False,
     "ui_unapplied_changes": False,
     "ui_error_message": None,
     "ui_more_info_link": None,


### PR DESCRIPTION
Resolves #86.
Closes menu components when the nearby drawer changes state. The Bounds Configuration menu closes when the main drawer changes state, and the Render Options menu closes when the axis drawer changes state.