### PR TITLE
Adding exception handling for cftime to datetime conversion

### DIFF
--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -204,14 +204,16 @@ class DatasetViewer:
             catalog_id = self.state.catalog.get("id")
             search_options = pan3d_catalogs.get_search_options(catalog_id)
             self.state.available_catalogs = [
-                {
-                    **catalog,
-                    "search_terms": [
-                        {"key": k, "options": v} for k, v in search_options.items()
-                    ],
-                }
-                if catalog.get("id") == catalog_id
-                else catalog
+                (
+                    {
+                        **catalog,
+                        "search_terms": [
+                            {"key": k, "options": v} for k, v in search_options.items()
+                        ],
+                    }
+                    if catalog.get("id") == catalog_id
+                    else catalog
+                )
                 for catalog in self.state.available_catalogs
             ]
             for catalog in self.state.available_catalogs:
@@ -504,13 +506,13 @@ class DatasetViewer:
     def _get_datetime_label(self, dtype, v) -> str:
         if dtype.kind in ["O", "M"]:  # is datetime
             try:
-                return (pandas.to_datetime(v).strftime("%b %d %Y %H:%M"))
+                return pandas.to_datetime(v).strftime("%b %d %Y %H:%M")
             except Exception:
                 # Get around the case where certain cftime objects do not
                 # readily agree with conversion to datetime objects
                 return str(v)
         elif dtype.kind in ["m"]:  # is timedelta
-            return (f"{pandas.to_timedelta(v).total_seconds()} seconds")
+            return f"{pandas.to_timedelta(v).total_seconds()} seconds"
         elif isinstance(v, float):
             return str(round(v))
         else:

--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -7,7 +7,6 @@ import pyvista
 import geovista
 import numpy
 import base64
-from datetime import datetime as dt
 from io import BytesIO
 from PIL import Image
 from pathlib import Path
@@ -506,7 +505,7 @@ class DatasetViewer:
         if dtype.kind in ["O", "M"]:  # is datetime
             try:
                 return (pandas.to_datetime(v).strftime("%b %d %Y %H:%M"))
-            except Exception as e:
+            except Exception:
                 # Get around the case where certain cftime objects do not
                 # readily agree with conversion to datetime objects
                 return str(v)
@@ -516,7 +515,6 @@ class DatasetViewer:
             return str(round(v))
         else:
             return str(v)
-
 
     def _data_array_changed(self) -> None:
         dataset = self.builder.dataset


### PR DESCRIPTION
It appears that certain cftime objects do not readily support conversion to DateTime objects. This change just returns the string for the cftime object in such a failure.
This also fixes two failing examples:
`example_config_cmip` and `example_config_esgf`

  
  