### PR TITLE
Remove intentional typo

### DIFF
--- a/pan3d/dataset_viewer.py
+++ b/pan3d/dataset_viewer.py
@@ -162,8 +162,7 @@ class DatasetViewer:
                             self.ctrl.push_camera = plot_view.push_camera
                             self.plot_view = plot_view
         # turn on axis orientation widget by default with state var from pyvista
-        # (typo in visibility is intentional, done to match pyvista)
-        self.state[f"{self.ctrl.get_plotter()._id_name}_axis_visiblity"] = True
+        self.state[f"{self.ctrl.get_plotter()._id_name}_axis_visibility"] = True
         return self._ui
 
     # -----------------------------------------------------


### PR DESCRIPTION
Pyvista recently fixed some typos that existed in the plotter trame state: https://github.com/pyvista/pyvista/pull/6403. We previously used the same typo to be compatible with that state, and it is no longer needed. 

This should only be merged once the Pyvista change has been included in a release.