### PR TITLE
Fixing ESGF example : Set time dimension to t instead of z

### DIFF
--- a/examples/example_config_esgf.json
+++ b/examples/example_config_esgf.json
@@ -7,7 +7,7 @@
         "name": "sfcWind",
         "x": "lon",
         "y": "lat",
-        "z": "time"
+        "t": "time"
     },
     "ui": {
         "main_drawer": false,


### PR DESCRIPTION
  This change sets the time dimension of the data to the T coordinate
  instead of the Z coordinate while the example launches.