### PR TITLE
fix: force scalar mapping to use LUT

### DIFF
--- a/src/pan3d/widgets/color_by.py
+++ b/src/pan3d/widgets/color_by.py
@@ -412,3 +412,4 @@ class ColorBy(html.Div):
         mapper.SelectColorArray(self.color_by)
         mapper.SetScalarRange(self.color_min, self.color_max)
         mapper.SetScalarVisibility(1)
+        mapper.SetColorModeToMapScalars()  # Critical fix: Force use of lookup table


### PR DESCRIPTION
This is to fix the issues @johnkit mentioned about not being able to color the COSEM datasets. #211 